### PR TITLE
Add exception for diagnostic mods/plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ To report a exploit, or vulnerability in Resonite please review, and follow our 
 - **Do not hijack issues for another feature/bug**, make another issue instead. Issues should never have comments of type "While you're at it, can you also do this?", it will not be considered and will get lost when the original problem in the issue gets solved
 - **Provide a link** (public folder or world) to content that replicates the issue (ensure replication worlds have their metadata set to allow access from anyone)
 - **Try to troubleshoot** and isolate the problem first before reporting it (e.g. if it is a complex ProtoFlux creation try to identify the specific node/node group that is not behaving as expected- strip down as much as possible from the item/world while still producing the bug)
-- **Provide a clean log file** from replicating the issue (**DO NOT USE MODS OR PLUGINS**, launch the client, load the replication item/world, replicate the issue, and exit)
+- **Ensure that the issue happens WIHOUT MODS OR PLUGINS** - sometimes mods or plugins can be source of the issues, so before you submit, make sure it occurs without them
+- **Provide a clean log file** from replicating the issue (**DO NOT USE MODS OR PLUGINS** except for diagnostic (see below), launch the client, load the replication item/world, replicate the issue, and exit)
 - **Report which version** of the app the problem was first observed on, as well as other relevant information (your OS, hardware, etc. as specified in the issue template)
 - **Use objective, and respectful language** for any posts/comments submitted (negativity, hateful/angry issues/comments are liable to be edited or removed)
 - **Use short, but descriptive tittle** as vague titles (e.g. "Issue with system" instead of "System breaks when I grab thing") are much more likely to get overlooked and skimmed over
@@ -25,5 +26,13 @@ To report a exploit, or vulnerability in Resonite please review, and follow our 
 
 # How we prioritize issues
 We use a number of factors when prioritizing issues. If you'd like to learn more and help increase the likelihood that your issue gets addressed, [read our HOW_WE_PRIORITIZE document here](HOW_WE_PRIORITIZE.md).
+
+# Using Diagnostic mods/plugins
+We will accept additional diagnostic data produced by mods specifically made to diagnose given issue and provide more helpful context and information. In some cases these might be necessary to demonstrate certain issues, as they might not be visible directly or show in the log or can provide helpful information to help us narrow down the issue faster.
+
+If you want to create and use such mod/plugin for report, please ensure the following:
+- The issue must still occur without any mods present - in other words, ensure that the issue is problem with vanilla client
+- Please provide the diagnostic data in the issue itself - we might not run (in fact, in a lot of cases we won't) the mod ourselves
+- Providing the source of the mod can be helpful as well to provide more context, even when we don't run it
 
 **Thank you for your reports, and feedback.**


### PR DESCRIPTION
We've had a few cases, where certain issues would be nearly impossible to show a replication for without using a mod - e.g. when certain procedural meshes would update too frequently when they shouldn't. 

There's a number of other cases, where using a mod for diagnostic purposes can provide us with useful additional data that can speed up the diagnosis and narrowing down the issue on our end. 

Since the reason for not allowing mods in replication is to ensure that mods aren't the cause of the problem and don't add a bunch of "junk" to log - or remove crucial info from it, I think it's suitable to add an explicit exception specifically for diagnostic mods.

I've worded things so it's clear that the issue must still occur without the mod, but that we will accept reports that do use mods made specifically to help diagnose particular issue - as long as no other mods are present.

I'm making this PR so this can be reviewed by other team members, before we commit this to our official guidelines. 