### PR TITLE
External service issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/external-report.yml
+++ b/.github/ISSUE_TEMPLATE/external-report.yml
@@ -11,13 +11,15 @@ body:
       required: true
   - type: dropdown
     id: which-service
-    label: Which service does the issue occurs on?
-    options:
-      - Moderation/Support portal
-      - Accounts website
-      - Metrics website
-      - Main Website
-      - Wiki
+    attributes:
+      label: Which service does the issue occurs on?
+      multiple: false
+      options:
+        - Moderation/Support portal
+        - Accounts website
+        - Metrics website
+        - Main Website
+        - Wiki
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/external-report.yml
+++ b/.github/ISSUE_TEMPLATE/external-report.yml
@@ -1,0 +1,27 @@
+name: External service
+description: When an external service (moderation portal, metrics, etc) isn't working as expected.
+labels: [external]
+body:
+  - type: textarea
+    id: Describe
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of what the issue is.
+    validations:
+      required: true
+  - type: dropdown
+    id: which-service
+    label: Which service does the issue occurs on?
+    options:
+      - Moderation/Support portal
+      - Accounts website
+      - Metrics website
+      - Main Website
+      - Wiki
+    validations:
+      required: true
+  - type: textarea
+    id: reporters
+    attributes:
+      label: Reporters
+      description: Usernames / Discord handles of anyone (including yourself) who has reported/replicated this bug (will be used to credit in release notes).

--- a/.github/ISSUE_TEMPLATE/external-report.yml
+++ b/.github/ISSUE_TEMPLATE/external-report.yml
@@ -2,13 +2,6 @@ name: External service
 description: When an external service (moderation portal, metrics, etc) isn't working as expected.
 labels: [external]
 body:
-  - type: textarea
-    id: Describe
-    attributes:
-      label: Describe the issue
-      description: A clear and concise description of what the issue is.
-    validations:
-      required: true
   - type: dropdown
     id: which-service
     attributes:
@@ -20,6 +13,13 @@ body:
         - Metrics website
         - Main Website
         - Wiki
+    validations:
+      required: true
+  - type: textarea
+    id: Describe
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of what the issue is.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
This PR adds:
- Template for external service issues & requests

This clearly created a separation for external services such as the moderation portal, wiki and others, as they do not require log files and other information we usually need when reporting regular bugs.