### PR TITLE
issue-templates: Split prerelease template into bug and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/prerelease-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/prerelease-bug-report.yml
@@ -1,19 +1,26 @@
-name: Prerelease Feedback
-description: Bug reports and feedback relating to prerelease builds of Resonite.
-labels: prerelease
+name: Prerelease Bug Report
+description: Bug reports relating to prerelease builds of Resonite.
+labels: [prerelease, bug]
 body:
   - type: textarea
     id: Describe
     attributes:
-      label: Describe the issue.
-      description: A clear and concise description of what the issue is?
+      label: Describe the bug?
+      description: A clear and concise description of what the bug is?
     validations:
       required: true
   - type: textarea
     id: reproduction
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the behavior. If relevant, please include a link to content that exhibits this issue via a public folder, or world. recreate the issue in a new grid space template, and edit the world's metadata to 'anyone'.
+      description: Steps to reproduce the behavior. Use bulletpoints and keep them as simple as possible - any steps that are not necessary to reproduce the issue should be omited.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-item
+    attributes:
+      label: Reproduction Item/World
+      description: Please include a link to content that replicates this issue. This can be link to public folder/world (make sure it's marked public please or that world access is set to Anyone) or .ResonitePackage file uploaded directly here. If the issue cannot be replicated through an item/world, just type "N/A". 
     validations:
       required: true
   - type: textarea
@@ -57,7 +64,7 @@ body:
     id: log-files
     attributes:
       label: Log Files
-      description: Please provide a clean log file from replicating this issue. **Please also ensure this issue only occurs on the prerelease build.** Information on the different kinds of log files and where to find them can be found on our [wiki](https://wiki.resonite.com/Log_Files).
+      description: Please provide a clean log file from replicating this issue.(**DO NOT USE MODS**. Start the client, replicate the issue and exit immediately.) Information on the different kinds of log files and where to find them can be found on our [wiki](https://wiki.resonite.com/Log_Files).
     validations:
       required: true
   - type: textarea
@@ -71,4 +78,4 @@ body:
     id: reporters
     attributes:
       label: Reporters
-      description: Usernames / Discord handles of anyone (including yourself) who has reported/replicated this feedback (will be used to credit in release notes).
+      description: Usernames / Discord handles of anyone (including yourself) who has reported/replicated this bug (will be used to credit in release notes).

--- a/.github/ISSUE_TEMPLATE/prerelease-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/prerelease-feature-request.yml
@@ -1,0 +1,37 @@
+name: Prerelease Feature Request
+description: Recommend a prerelease-related feature for consideration.
+labels: [prerelease, "New Feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+  - type: textarea
+    id: requesters
+    attributes:
+      label: Requesters
+      description: Usernames / Discord handles of anyone (including yourself) who has requested this feature (will be used to credit in release notes).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Issue repository for Resonite. Please log any bug reports, or feature requests h
 - [:bug: To Report a Bug Click Here](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/new?labels=bug&projects=&template=bug-report.yml)
 - [:computer: To Request a Feature Click Here](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/new?labels=enhancement&projects=&template=feature-request.yml)
 - [:paintbrush: To Report an Issue with Content such as the Cloud Home Click Here](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/new?assignees=+AegisTheWolf%2C+RyuviTheViali%2C+RueShejn&labels=content&projects=&template=content-issue.yml)
-- [:satellite: To Report a bug appearing on a pre-release Click Here](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/new?template=prerelease.yml)
+- [:satellite: To Report a Bug appearing on a pre-release Click Here](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/new?template=prerelease-bug-report.yml)
+- [:test_tube: To Request a pre-release Feature Click Here](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/new?template=prerelease-feature-request.yml)
 - [:lock: To Report a Security issue please open a ticket](https://support.resonite.com/)
 
 # Reporting Requirements


### PR DESCRIPTION
This splits out the prerelease issue template into two categories that are exact duplicates of the existing "feature request" and "bug report" templates, except they add the prerelease tag. There are many cases where a prerelease-only feature request is needed, and trying to cram that information into a template for bug reports doesn't make much sense.

For general prerelease *feedback*, as in the "hey this thing works really nice" sort of feedback, I think those things generally belong as GitHub Discussion posts and not as issues, so I've removed that terminology.

Merging this would need a sister PR to logscanner-action to not consider `prerelease` issues as needing logs.

I'm making this mostly as a working proposal so if this isn't the direction wanted for prerelease issues, this can be closed.