### PR TITLE
add in headless as a platform and remove andoid/quest

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -52,7 +52,8 @@ body:
       options:
         - "Windows"
         - "Linux"
-        - "Android / Quest"
+        - "Headless Windows"
+        - "Headless Linux"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
as is we dont have android/quest and we do have headless as its own seperate thing. so to reflect this this pr removes android/quest. It also simultaniously adds in Headless Windows and headless Linux platforms as some bugs only occur on headless's  (one example being pre splitening the infinite tree crash occurred on headless's way more often than on the client)