### PR TITLE
Add stale bot to repository

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           days-before-stale: '90'
           stale-issue-message: >
-            Hi, this issue has had a request for more information more than 90 days ago.
+            Hi, this issue has had a request for more information for more than 90 days.
             
             If you reported a bug:
             - Has the issue been solved by an update in the meanwhile?


### PR DESCRIPTION
Adds a new workflow configuring the stale bot.

TLDR;
- Checks every 6 hours
- Only applies to the "needs more information" label
- Only sends a reminder after 90 days
- Gives the user 30 days to respond or provide the information required
- If after 30 days no activity is detected, issue is closed