### PR TITLE
Increase limits on stale bot

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/stale@v10
         with:
           days-before-stale: '90'
+          operations-per-run: '1000'
           stale-issue-message: >
             Hi, this issue has had a request for more information for more than 90 days.  
               


### PR DESCRIPTION
Small PR that tweaks the number of actions per run for the Stale bot to 1k.

The default per run is 30, but the token can be used for 5k operations an hour.

This should improve the speed at which it checks issues a bit.