### PR TITLE
Use SHA-pinning for GitHub Actions

### DIFF
--- a/.github/workflows/log-checker.yml
+++ b/.github/workflows/log-checker.yml
@@ -13,6 +13,6 @@ jobs:
       contents: read
     steps:
       - name: Check if log file exists
-        uses: Yellow-Dog-Man/logscanner-action@v1.2.3
+        uses: Yellow-Dog-Man/logscanner-action@bd717cd37b5ee82719fbce2206b2a15d257abc20 # v1.2.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Run stale bot'
-        uses: actions/stale@v10
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-stale: '90'
           operations-per-run: '1000'


### PR DESCRIPTION
SHA pinning enforcement for GitHub Actions will begin soon, meaning those not using that will fail before execution.

This PR pins all the external Actions referenced by the repo workflows.