### PR TITLE
Remove redundant fields from bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -37,29 +37,6 @@ body:
       description: Add media to help explain your problem
     validations:
       required: false
-  - type: input
-    id: version
-    attributes:
-      label: Resonite Version Number
-      placeholder: 1.2.3 (USE AN ACTUAL VERSION NUMBER)
-    validations:
-      required: true
-  - type: dropdown
-    id: platforms
-    attributes:
-      label: What Platforms does this occur on?
-      multiple: true
-      options:
-        - "Windows"
-        - "Linux"
-        - "Android / Quest"
-    validations:
-      required: true
-  - type: input
-    id: headset
-    attributes:
-      label: What headset if any do you use?
-      placeholder: Vive, Desktop?
   - type: textarea
     id: log-files
     attributes:


### PR DESCRIPTION
Since we parse this information from the log nowadays, we don't need this information to be manually filled out anymore.