### PR TITLE
Parity with #6733

### DIFF
--- a/.github/ISSUE_TEMPLATE/prerelease-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/prerelease-bug-report.yml
@@ -44,22 +44,6 @@ body:
       placeholder: 1.2.3 (USE AN ACTUAL VERSION NUMBER)
     validations:
       required: true
-  - type: dropdown
-    id: platforms
-    attributes:
-      label: What Platforms does this occur on?
-      multiple: true
-      options:
-        - "Windows"
-        - "Linux"
-        - "Android / Quest"
-    validations:
-      required: true
-  - type: input
-    id: headset
-    attributes:
-      label: What headset if any do you use?
-      placeholder: Vive, Desktop?
   - type: textarea
     id: log-files
     attributes:


### PR DESCRIPTION
noticed that the pre-release template still has the redundant fields that froox nuked in #6733. thought id nuke those except the version number since it can help in nailing down the exact version that bugs can be seen in (if ya want i can nuke it as well)