### PR TITLE
Fix#: remove trigger on prerelease tag

### DIFF
--- a/.github/workflows/log-checker.yml
+++ b/.github/workflows/log-checker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-log:
-    if: github.event.label.name == 'bug' || github.event.label.name == 'prerelease'
+    if: github.event.label.name == 'bug'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
This should fix duplicate log bot entries when a prerelease bug report is opened.

The template was modified a while ago without this logic being updated.